### PR TITLE
Remove sys prefix from syscalls

### DIFF
--- a/doc/glossary.txt
+++ b/doc/glossary.txt
@@ -55,11 +55,11 @@ depth ( -> u )
 
 
 # Operating System interface
-sysread ( fd a u -> u' )
+read ( fd a u -> u' )
    Read at most `u` bytes from file descriptor `fd` into address `a`.
    Return number of bytes read.
 
-syswrite ( fd a u -> u' )
+write ( fd a u -> u' )
    Write `u` bytes starting at address `a` to file descriptor `fd`.
    Return number of bytes written.
 
@@ -74,11 +74,11 @@ create-file ( a u mode -> fd )
    Create file named by buffer and open it in given `mode`.
    Return file descriptor.
 
-sysclose ( fd -> err )
+close ( fd -> err )
    Close file descriptor `fd`.
    Return error code, 0 on success.
 
-sysseek ( off ref fd -> off' )
+lseek ( off ref fd -> off' )
    Reposition file descriptor `fd` to offset `off` relative to `ref`.
    On success, return resulting offset from beginning of file. On error,
    return -1.
@@ -89,7 +89,7 @@ file-position ( fd -> u  )
 fsize ( fd -> u )
    Return file size.
 
-sysmmap ( addr length prot flags fh offset -> addr' )
+mmap ( addr length prot flags fh offset -> addr' )
    Map file to memory.
    Check OS manuals for the meaning of arguments and return value.
 
@@ -97,7 +97,7 @@ fmap ( fd -> a u )
    Map file to memory.
    Return pointer to mapped file.
 
-sysmunmap ( a u -> err )
+munmap ( a u -> err )
    Unmap file mapping at `a` with length `u`.
 
 syscall1 ( n1 syscall# -> nr )

--- a/examples/cat.ns
+++ b/examples/cat.ns
@@ -8,7 +8,7 @@
 
 8192 value /buf
 create buf /buf allot
-: >buf ( fd -> n )  buf /buf sysread ;
+: >buf ( fd -> n )  buf /buf read ;
 : .buf ( u -> )     buf swap type ;
 
 : cat ( fd -> )  dup >buf  dup 1 < if drop drop exit then  .buf cat ;

--- a/examples/hdump.ns
+++ b/examples/hdump.ns
@@ -10,7 +10,7 @@
 0 value r/o
 
 : ?fsize ( a u -> u' )
-  r/o 0 open-file  dup fsize  swap sysclose " can't retrieve file size" ?abort ;
+  r/o 0 open-file  dup fsize  swap close " can't retrieve file size" ?abort ;
 
 0 value /line
 variable off
@@ -31,10 +31,10 @@ variable remaining
 : update ( u -> )       negate remaining +! ;
 
 : open ( a u -> )     r/o 0 open-file dup 0 < " can't open file" ?abort to fd ;
-: position ( u -> )   0 fd sysseek 0 < " can't position file" ?abort ;
-: fdclose               fd sysclose drop ;
+: position ( u -> )   0 fd lseek 0 < " can't position file" ?abort ;
+: fdclose               fd close drop ;
 : fdread ( a -> u )
-   fd swap size sysread  dup 0 < " can't read from file" ?abort
+   fd swap size read  dup 0 < " can't read from file" ?abort
    dup update ;
 
 : reserve    /line allot ;

--- a/src/arm64/Darwin.s
+++ b/src/arm64/Darwin.s
@@ -20,7 +20,7 @@ sysopen:
     ldp x30, xzr, [sp], #16
     ret
 
-syscreate:
+syscreat:
     stp x30, xzr, [sp, #-16]!
     mov x1, x0
     drop_
@@ -59,7 +59,7 @@ syswrite:
     ldp x30, xzr, [sp], #16
     ret
 
-sysseek:
+syslseek:
     stp x30, xzr, [sp, #-16]!
     mov x9, x0
     drop_

--- a/src/arm64/boot.s
+++ b/src/arm64/boot.s
@@ -644,120 +644,120 @@ sysexit_header:
     .ascii "sysexit"
 
     .align 8
-sysclose_header:
+close_header:
     .quad sysexit_header
     .quad sysclose
-    .byte 8
-    .ascii "sysclose"
+    .byte 5
+    .ascii "close"
 
     .align 8
-syscreate_header:
-    .quad sysclose_header
-    .quad syscreate
-    .byte 9
-    .ascii "syscreate"
+creat_header:
+    .quad close_header
+    .quad syscreat
+    .byte 5
+    .ascii "creat"
 
     .align 8
-sysopen_header:
-    .quad syscreate_header
+open_header:
+    .quad creat_header
     .quad sysopen
-    .byte 7
-    .ascii "sysopen"
+    .byte 4
+    .ascii "open"
 
     .align 8
-syserrno_header:
-    .quad sysopen_header
+errno_header:
+    .quad open_header
     .quad syserrno
-    .byte 8
-    .ascii "syserrno"
+    .byte 5
+    .ascii "errno"
 
     .align 8
-sysread_header:
-    .quad syserrno_header
+read_header:
+    .quad errno_header
     .quad sysread
-    .byte 7
-    .ascii "sysread"
+    .byte 4
+    .ascii "read"
 
     .align 8
-syswrite_header:
-    .quad sysread_header
+write_header:
+    .quad read_header
     .quad syswrite
-    .byte 8
-    .ascii "syswrite"
+    .byte 5
+    .ascii "write"
 
     .align 8
-sysseek_header:
-    .quad syswrite_header
-    .quad sysseek
-    .byte 7
-    .ascii "sysseek"
+lseek_header:
+    .quad write_header
+    .quad syslseek
+    .byte 5
+    .ascii "lseek"
 
     .align 8
-sysrealloc_header:
-    .quad sysseek_header
+realloc_header:
+    .quad lseek_header
     .quad sysrealloc
-    .byte 10
-    .ascii "sysrealloc"
+    .byte 7
+    .ascii "realloc"
 
     .align 8
-sysmalloc_header:
-    .quad sysrealloc_header
+malloc_header:
+    .quad realloc_header
     .quad sysmalloc
-    .byte 9
-    .ascii "sysmalloc"
+    .byte 6
+    .ascii "malloc"
 
     .align 8
-sysfree_header:
-    .quad sysmalloc_header
+free_header:
+    .quad malloc_header
     .quad sysfree
-    .byte 7
-    .ascii "sysfree"
+    .byte 4
+    .ascii "free"
 
     .align 8
-sysmunmap_header:
-    .quad sysfree_header
+munmap_header:
+    .quad free_header
     .quad sysmunmap
-    .byte 9
-    .ascii "sysmunmap"
+    .byte 6
+    .ascii "munmap"
 
     .align 8
-sysmmap_header:
-    .quad sysmunmap_header
+mmap_header:
+    .quad munmap_header
     .quad sysmmap
-    .byte 7
-    .ascii "sysmmap"
+    .byte 4
+    .ascii "mmap"
 
     .align 8
-sysdlopen_header:
-    .quad sysmmap_header
+dlopen_header:
+    .quad mmap_header
     .quad sysdlopen
     .byte 6
     .ascii "dlopen"
 
     .align 8
-sysdlsym_header:
-    .quad sysdlopen_header
+dlsym_header:
+    .quad dlopen_header
     .quad sysdlsym
     .byte 5
     .ascii "dlsym"
 
     .align 8
-sysdlclose_header:
-    .quad sysdlsym_header
+dlclose_header:
+    .quad dlsym_header
     .quad sysdlclose
     .byte 7
     .ascii "dlclose"
 
     .align 8
-sysdlerror_header:
-    .quad sysdlclose_header
+dlerror_header:
+    .quad dlclose_header
     .quad sysdlerror
     .byte 7
     .ascii "dlerror"
 
     .align 8
 sysgetenv_header:
-    .quad sysdlerror_header
+    .quad dlerror_header
     .quad sysgetenv
     .byte 8
     .ascii "(getenv)"

--- a/src/cygwin/os.s
+++ b/src/cygwin/os.s
@@ -57,7 +57,7 @@ sysclose:
     add $(32 + 8), %rsp
     ret
 
-sysseek:
+syslseek:
     sub $(32 + 8), %rsp
     mov %rax, %rcx
     drop_
@@ -154,7 +154,7 @@ sysdlerror:
     add $(32 + 8), %rsp
     ret
 
-_getenv:
+sysgetenv:
     mov %rax, %rcx
     call getenv
     ret

--- a/src/dicts.s
+++ b/src/dicts.s
@@ -7,127 +7,127 @@
 # Forth
 #
     .align 8
-syserrno_header:
+errno_header:
     .quad 0
     .quad syserrno
-    .byte 8
-    .ascii "syserrno"
+    .byte 5
+    .ascii "errno"
 
     .align 8
-sysread_header:
-    .quad syserrno_header
+read_header:
+    .quad errno_header
     .quad sysread
-    .byte 7
-    .ascii "sysread"
+    .byte 4
+    .ascii "read"
 
     .align 8
-syswrite_header:
-    .quad sysread_header
+write_header:
+    .quad read_header
     .quad syswrite
-    .byte 8
-    .ascii "syswrite"
+    .byte 5
+    .ascii "write"
 
     .align 8
 sysexit_header:
-    .quad syswrite_header
+    .quad write_header
     .quad sysexit
     .byte 7
     .ascii "sysexit"
 
     .align 8
-sysopen_header:
+open_header:
     .quad sysexit_header
     .quad sysopen
-    .byte 7
-    .ascii "sysopen"
+    .byte 4
+    .ascii "open"
 
     .align 8
-syscreate_header:
-    .quad sysopen_header
-    .quad syscreate
-    .byte 9
-    .ascii "syscreate"
+creat_header:
+    .quad open_header
+    .quad syscreat
+    .byte 5
+    .ascii "creat"
 
     .align 8
-sysclose_header:
-    .quad syscreate_header
+close_header:
+    .quad creat_header
     .quad sysclose
-    .byte 8
-    .ascii "sysclose"
+    .byte 5
+    .ascii "close"
 
     .align 8
-sysseek_header:
-    .quad sysclose_header
-    .quad sysseek
-    .byte 7
-    .ascii "sysseek"
+lseek_header:
+    .quad close_header
+    .quad syslseek
+    .byte 5
+    .ascii "lseek"
 
     .align 8
-sysmmap_header:
-    .quad sysseek_header
+mmap_header:
+    .quad lseek_header
     .quad sysmmap
-    .byte 7
-    .ascii "sysmmap"
+    .byte 4
+    .ascii "mmap"
 
     .align 8
-sysmunmap_header:
-    .quad sysmmap_header
+munmap_header:
+    .quad mmap_header
     .quad sysmunmap
-    .byte 9
-    .ascii "sysmunmap"
+    .byte 6
+    .ascii "munmap"
 
     .align 8
-sysdlclose_header:
-    .quad sysmunmap_header
+dlclose_header:
+    .quad munmap_header
     .quad sysdlclose
     .byte 7
     .ascii "dlclose"
 
     .align 8
-sysdlerror_header:
-    .quad sysdlclose_header
+dlerror_header:
+    .quad dlclose_header
     .quad sysdlerror
     .byte 7
     .ascii "dlerror"
 
     .align 8
-sysdlsym_header:
-    .quad sysdlerror_header
+dlsym_header:
+    .quad dlerror_header
     .quad sysdlsym
     .byte 5
     .ascii "dlsym"
 
     .align 8
-sysdlopen_header:
-    .quad sysdlsym_header
+dlopen_header:
+    .quad dlsym_header
     .quad sysdlopen
     .byte 6
     .ascii "dlopen"
 
     .align 8
-sysmalloc_header:
-    .quad sysdlopen_header
+malloc_header:
+    .quad dlopen_header
     .quad sysmalloc
-    .byte 9
-    .ascii "sysmalloc"
+    .byte 6
+    .ascii "malloc"
 
     .align 8
-sysrealloc_header:
-    .quad sysmalloc_header
+realloc_header:
+    .quad malloc_header
     .quad sysrealloc
-    .byte 10
-    .ascii "sysrealloc"
+    .byte 7
+    .ascii "realloc"
 
     .align 8
-sysfree_header:
-    .quad sysrealloc_header
+free_header:
+    .quad realloc_header
     .quad sysfree
-    .byte 7
-    .ascii "sysfree"
+    .byte 4
+    .ascii "free"
 
     .align 8
 syscall6_header:
-    .quad sysfree_header
+    .quad free_header
     .quad syscall6
     .byte 8
     .ascii "syscall6"

--- a/src/file.ns
+++ b/src/file.ns
@@ -2,11 +2,11 @@
 \ Copyright (c) 2018-2022 Iruatã Martins dos Santos Souza
 
 forth
-: create-file ( a u mode -> fd )       push s>z pop syscreate ;
-: open-file ( a u flags mode -> fd )   2push s>z 2pop sysopen ;
+: create-file ( a u mode -> fd )       push s>z pop creat ;
+: open-file ( a u flags mode -> fd )   2push s>z 2pop open ;
 
 : read-byte ( fd -> b err )
-   [ here dup 0 1, ] lit  1 sysread  1 ~= if  0 true exit  then
+   [ here dup 0 1, ] lit  1 read  1 ~= if  0 true exit  then
    lit 1@ false ;
 
 : read-line ( fd a u -> u' )
@@ -18,13 +18,13 @@ forth
    drop arest ;
 
 : write-byte ( fd byte -> n )
-   [ here dup 0 1, ] lit  1!  lit 1 syswrite ;
+   [ here dup 0 1, ] lit  1!  lit 1 write ;
 
 : write-line ( fd a u -> n )
-   2push dup 2pop  syswrite  dup 0 < if  nip exit  then
+   2push dup 2pop  write  dup 0 < if  nip exit  then
    swap 10 write-byte  1 ~= if  drop -1 exit  then 1 + ;
 
-: file-position ( fd -> n' )   push 0 1 pop sysseek ;
+: file-position ( fd -> n' )   push 0 1 pop lseek ;
 
 ( File loading )
 : input@ ( -> fd buf tot used pos 'refill )
@@ -39,13 +39,13 @@ forth
 : restore-input
    pop pop  pop pop pop pop pop pop input!  push push ;
 
-: fsize ( fd -> u )   push 0 2 pop sysseek ;
+: fsize ( fd -> u )   push 0 2 pop lseek ;
 
 : fmap ( fd -> a u ) \ PROT_READ MAP_PRIVATE
-   dup push fsize  0 over 1 2 pop 0 sysmmap  swap ;
+   dup push fsize  0 over 1 2 pop 0 mmap  swap ;
 
 
-\ After a file is mmaped for inclusion the input state is intot = filesize,
+\ After a file is mapped for inclusion the input state is intot = filesize,
 \ inused = 0, inpos = 0. Each refill then advances inused to after the next
 \ newline. Hence, even though the whole file is available at the onset, the
 \ interpreter sees only one line at a time.
@@ -59,7 +59,7 @@ forth
    save-input  dup dup fmap  over -1 = if drop exit then
    0 0 ['] frefill input!
    push rel pop
-   sysclose drop  inbuf @ intot @ sysmunmap drop
+   close drop  inbuf @ intot @ munmap drop
    restore-input  false ;
 
 : include   10 parse included " can't include file" ?abort ;

--- a/src/x86_64/Darwin.s
+++ b/src/x86_64/Darwin.s
@@ -75,7 +75,7 @@ sysopen:
     epilog
     ret
 
-syscreate:
+syscreat:
     prolog
     mov %rax, %rsi
     drop_
@@ -93,7 +93,7 @@ sysclose:
     epilog
     ret
 
-sysseek:
+syslseek:
     prolog
     mov %rax, %rdi
     drop_

--- a/src/x86_64/sysv.s
+++ b/src/x86_64/sysv.s
@@ -71,7 +71,7 @@ sysopen:
     epilog
     ret
 
-syscreate:
+syscreat:
     prolog
     mov %rax, %rsi
     drop_
@@ -89,7 +89,7 @@ sysclose:
     epilog
     ret
 
-sysseek:
+syslseek:
     prolog
     mov %rax, %rdi
     drop_

--- a/test/fileio.ns
+++ b/test/fileio.ns
@@ -13,17 +13,17 @@ create rbuf #wbuf 5 +  dup allot  value /rbuf
    fname #fname 420 create-file
    dup 0 < ?fail  to fd ;
 
-: test-close   fd sysclose ?fail ;
+: test-close   fd close ?fail ;
 
 : test-open
    fname #fname 2 0 open-file
    dup 0 < ?fail  to fd ;
 
 : test-write
-   fd wbuf #wbuf syswrite  #wbuf ~= ?fail ;
+   fd wbuf #wbuf write  #wbuf ~= ?fail ;
 
 : test-read
-   fd rbuf /rbuf sysread
+   fd rbuf /rbuf read
    dup 1 < " test-read: read failed" ?abort
 
    push  wbuf rbuf  pop mem= not


### PR DESCRIPTION
Also syscreate -> creat, sysseek -> lseek.
Keep sysexit as such.